### PR TITLE
Removed ? from delete_if as not a valid method

### DIFF
--- a/lib/diamond/clock.rb
+++ b/lib/diamond/clock.rb
@@ -59,7 +59,7 @@ module Diamond
     # @return [Array<Arpeggiator>]
     def remove(arpeggiator)
       arpeggiators = [arpeggiator].flatten
-      @arpeggiators.delete_if? { |arpeggiator| arpeggiators.include?(arpeggiator) }
+      @arpeggiators.delete_if { |arpeggiator| arpeggiators.include?(arpeggiator) }
       @arpeggiators
     end
 


### PR DESCRIPTION
I think what was meant was delete_if.

Ruby throws an error with delete_if? but works fine with delete_if.